### PR TITLE
Generate width and height attributes for SVG image blocks

### DIFF
--- a/lib/asciidoctor-plantuml/svg.rb
+++ b/lib/asciidoctor-plantuml/svg.rb
@@ -1,0 +1,18 @@
+require_relative 'binaryio'
+
+module Asciidoctor
+  module PlantUml
+    module SVG
+      SVG_SIZE_REGEX = /style="width:(?<width>\d+)px;height:(?<height>\d+)px/
+
+      def self.get_image_size(data)
+        match_data = SVG_SIZE_REGEX.match(data)
+        if match_data
+          [match_data[:width].to_i, match_data[:height].to_i]
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/plantuml_spec.rb
+++ b/spec/plantuml_spec.rb
@@ -70,6 +70,9 @@ User --> (Use the application) : Label
     expect(target).to_not be_nil
     expect(target).to match /\.svg/
     expect(File.exists?(target)).to be_true
+
+    expect(b.attributes['width']).to_not be_nil
+    expect(b.attributes['height']).to_not be_nil
   end
 
   it "should generate literal blocks when format is set to 'txt'" do


### PR DESCRIPTION
Resolves #3 by also generating width and height attributes for SVG images
