### PR TITLE
Add Cacoo support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,6 +63,7 @@ You should then register the extensions yourself at the appropriate time using t
 Once the extensions are enabled the following block types becomes available for your documents:
 
 - `blockdiag`, `actdiag`, `seqdiag`, `nwdiag`, `rackdiag` and `packetdiag`
+- `cacoo`
 - `ditaa`
 - `graphviz`
 - `plantuml`
@@ -90,6 +91,33 @@ The diagram blocks support the following attributes:
 
 . `target` (or 2nd position): the basename of the file to generate. If not specified an auto-generated name will be used.
 . `format` (or 3rd position): the output format. PlantUML blocks support `png`, `svg` and `txt`. Graphviz, Shaape and BlockDiag support `png` and `svg`. Ditaa only supports `png`.
+
+==== Adding a Cacoo diagram to your document
+
+You must have an account of https://cacoo.com/[Cacoo].
+You need to create an Caoo API Key at https://cacoo.com/profile/api[Cacoo API key config page]
+and set it to the environment variable `CACOO_API_KEY`.
+
+If you use bash or zsh, you can set it like the following:
+
+----
+export CACOO_API_KEY=_Your_Cacoo_API_key_here_
+----
+
+
+When you would like to add a diagram on Cacoo, you need the diagram ID.
+For example, if your diagram's URL is https://cacoo.com/diagrams/gJpqSQjwc7GFDAaI,
+your diagram ID is gJpqSQjwc7GFDAaI.
+
+You can add a diagram to your application, like the following example:
+
+----
+["cacoo"]
+---------------------------------------------------------------------
+_Your_diagram_ID_here_
+---------------------------------------------------------------------
+----
+
 
 == Contributing
 

--- a/lib/asciidoctor-diagram.rb
+++ b/lib/asciidoctor-diagram.rb
@@ -1,4 +1,5 @@
 require 'asciidoctor-diagram/blockdiag'
+require 'asciidoctor-diagram/cacoo'
 require 'asciidoctor-diagram/ditaa'
 require 'asciidoctor-diagram/graphviz'
 require 'asciidoctor-diagram/plantuml'

--- a/lib/asciidoctor-diagram/cacoo.rb
+++ b/lib/asciidoctor-diagram/cacoo.rb
@@ -1,0 +1,8 @@
+require 'asciidoctor/extensions'
+require_relative 'version'
+
+Asciidoctor::Extensions.register do
+  require_relative 'cacoo/extension'
+  block Asciidoctor::Diagram::CacooBlock, :cacoo
+  block_macro Asciidoctor::Diagram::CacooBlockMacro, :cacoo
+end

--- a/lib/asciidoctor-diagram/cacoo/extension.rb
+++ b/lib/asciidoctor-diagram/cacoo/extension.rb
@@ -1,0 +1,31 @@
+require_relative '../util/cli_generator'
+require_relative '../util/diagram'
+require 'net/https'
+
+module Asciidoctor
+  module Diagram
+    module CacooGenerator
+      def self.cacoo(c)
+        apiKey = ENV['CACOO_API_KEY']
+        diagramId = c.strip
+        # NOTE: See API document at https://cacoo.com/lang/en/api and
+        # https://cacoo.com/lang/en/api_image
+        url = "/api/v1/diagrams/#{diagramId}.png?apiKey=#{apiKey}"
+
+        https = Net::HTTP.new('cacoo.com', 443)
+        https.use_ssl = true
+        https.start {
+          response = https.get(url)
+          raise "Cacoo response status code was #{response.code}" if response.code != '200'
+          response.body
+        }
+      end
+    end
+
+    define_processors('Cacoo') do
+      register_format(:png, :image) do |c|
+        CacooGenerator.cacoo(c)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi, I added the [Cacoo](https://cacoo.com) support to the asciidoctor-diagram.
Please refer README.adoc for the usage.

I confirmed this pull request works successfully.
Could you review this?
Thanks.
