### PR TITLE
Use same destination-dir as asciidoctor when possible

### DIFF
--- a/lib/asciidoctor-diagram/extensions.rb
+++ b/lib/asciidoctor-diagram/extensions.rb
@@ -123,8 +123,7 @@ module Asciidoctor
         private
         def create_image_block(parent, source, attributes, format, generator_info)
           image_name = "#{source.image_name}.#{format}"
-          outdir = parent.document.attr('imagesoutdir') || parent.document.attr('outdir')
-          image_dir = parent.normalize_system_path parent.document.attr 'imagesdir', outdir
+          image_dir = image_output_dir(parent)
           image_file = parent.normalize_system_path image_name, image_dir
           metadata_file = parent.normalize_system_path "#{image_name}.cache", image_dir
 
@@ -158,12 +157,27 @@ module Asciidoctor
           image_attributes['alt'] ||= if title_text = attributes['title']
                                         title_text
                                       elsif target = attributes['target']
-                                        (File.basename target, (File.extname target) || '').tr '_-', ' '
+                                        (File.basename(target, File.extname(target)) || '').tr '_-', ' '
                                       else
                                         'Diagram'
                                       end
 
           Asciidoctor::Block.new parent, :image, :content_model => :empty, :attributes => image_attributes
+        end
+
+        def image_output_dir(parent)
+          document = parent.document
+
+          images_dir = document.attr('imagesoutdir')
+
+          if images_dir
+            base_dir = nil
+          else
+            base_dir = document.attr('outdir') || (document.respond_to?(:options) && document.options[:to_dir])
+            images_dir = document.attr('imagesdir')
+          end
+
+          parent.normalize_system_path(images_dir, base_dir)
         end
 
         def create_literal_block(parent, source, attributes, generator_info)

--- a/spec/plantuml_spec.rb
+++ b/spec/plantuml_spec.rb
@@ -297,6 +297,31 @@ Foo1 -> Foo2 : To boundary
     expect(File.exists?(File.expand_path(target, 'foo'))).to be true
   end
 
+  it "should write files to imagesoutdir if set" do
+    doc = <<-eos
+= Hello, PlantUML!
+Doc Writer <doc@example.com>
+
+== First Section
+
+[plantuml, format="svg"]
+----
+actor Foo1
+boundary Foo2
+Foo1 -> Foo2 : To boundary
+----
+    eos
+
+    d = Asciidoctor.load StringIO.new(doc), {:attributes => {'imagesoutdir' => 'bar', 'outdir' => 'foo'}}
+    b = d.find { |b| b.context == :image }
+
+    target = b.attributes['target']
+    expect(target).to_not be_nil
+    expect(File.exists?(target)).to be false
+    expect(File.exists?(File.expand_path(target, 'bar'))).to be true
+    expect(File.exists?(File.expand_path(target, 'foo'))).to be false
+  end
+
   it "should omit width/height attributes when generating docbook" do
     doc = <<-eos
 = Hello, PlantUML!


### PR DESCRIPTION
Resolves #39 as described in comments on 43d6ec1ea043513e1691a811f7d47338844eecec
