### PR TITLE
add adciidoc execution instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,6 +97,11 @@ The diagram blocks support the following attributes:
 . `target` (or 2nd position): the basename of the file to generate. If not specified an auto-generated name will be used.
 . `format` (or 3rd position): the output format. PlantUML blocks support `png`, `svg` and `txt`. Graphviz, Shaape and BlockDiag support `png` and `svg`. Ditaa only supports `png`.
 
+Once you have all of this in place and your original asciidoc contains a diagram block, it's time to build it into an HTML file with Asciidoctor-diagram magic! 
+When executing Asciidoctor, you must reference the Adciidoctor-diagram library, otherwise your diagam blocks won't be recognized as such. When executing Asciidoctor from the command line, do it using the -r parameter to reference an external library:
+$ asciidoctor -r asciidoctor-diagram doc.ad
+
+
 == Contributing
 
 . Fork it

--- a/README.adoc
+++ b/README.adoc
@@ -97,9 +97,10 @@ The diagram blocks support the following attributes:
 . `target` (or 2nd position): the basename of the file to generate. If not specified an auto-generated name will be used.
 . `format` (or 3rd position): the output format. PlantUML blocks support `png`, `svg` and `txt`. Graphviz, Shaape and BlockDiag support `png` and `svg`. Ditaa only supports `png`.
 
-Once you have all of this in place and your original asciidoc contains a diagram block, it's time to build it into an HTML file with Asciidoctor-diagram magic! 
-When executing Asciidoctor, you must reference the Adciidoctor-diagram library, otherwise your diagam blocks won't be recognized as such. When executing Asciidoctor from the command line, do it using the -r parameter to reference an external library:
-$ asciidoctor -r asciidoctor-diagram doc.ad
+Once you have all of this in place and your original AsciiDoc file contains a diagram block, it's time to build it into an HTML file with Asciidoctor Diagram magic! 
+When executing Asciidoctor, you must reference the Adciidoctor Diagram library, otherwise your diagam blocks won't be recognized as such. When executing Asciidoctor from the command line, do it using the -r parameter to reference this external library:
+
+$ asciidoctor -r asciidoctor-diagram doc.adoc
 
 
 == Contributing


### PR DESCRIPTION
I got stuck trying to use this extension, as I didn't realise using it was as easy as adding a parameter when executing it.
I got stuck following the examples in this document:
http://asciidoctor.org/news/2014/02/18/plain-text-diagrams-in-asciidoctor/
which was a lot more complicated and failed on asciidoctor 1.5.2
also, it was confusing that this doc referred to asciidoctor-diagrams as an "extension", but in the command line tool's help, the -r parameter added a "library" ... I wasn't sure this was the same thing

Thanks for this really nice tool!
Keep it up!