### PR TITLE
Avoid deprecation warning for Dir.exists with JRuby 9000

### DIFF
--- a/lib/asciidoctor-diagram/extensions.rb
+++ b/lib/asciidoctor-diagram/extensions.rb
@@ -153,7 +153,7 @@ module Asciidoctor
             metadata = source.create_image_metadata
             metadata['width'], metadata['height'] = params[:decoder].get_image_size(result)
 
-            FileUtils.mkdir_p(image_dir) unless Dir.exists?(image_dir)
+            FileUtils.mkdir_p(image_dir) unless Dir.exist?(image_dir)
             File.open(image_file, 'wb') { |f| f.write result }
             File.open(metadata_file, 'w') { |f| JSON.dump(metadata, f) }
           end


### PR DESCRIPTION
JRuby 9.0.0.0 issues a deprecation warning when loading the asciidoctor-diagram extension:
`warning: Dir.exists? is a deprecated name, use Dir.exist? instead`

And even the http://ruby-doc.org/core-2.2.3/Dir.html#method-c-exist-3F recommends not to use Dir.exists:

>  exists?(file_name) → true or false
> Deprecated method. Don’t use.

This PR simply replaces the call of `Dir.exists?` with the recommended `Dir.exist?`