### PR TITLE
Use blockdiag-font attribute to select the font for blockdiag diagrams.

### DIFF
--- a/lib/asciidoctor-diagram/blockdiag/extension.rb
+++ b/lib/asciidoctor-diagram/blockdiag/extension.rb
@@ -106,7 +106,10 @@ module Asciidoctor
         alt_cmd_name = "#{tool.downcase}3"
 
         CliGenerator.generate_stdin(which(parent, cmd_name, :alt_cmds => [alt_cmd_name]), format.to_s, source.to_s) do |tool_path, output_path|
-          [tool_path, '-o', Platform.native_path(output_path), "-T#{format.to_s}", '-']
+          args = [tool_path, '-o', Platform.native_path(output_path), "-T#{format.to_s}"]
+          args << "-f#{Platform.native_path(parent.document.attributes['blockdiag-font'])}" if parent.document.attributes.key?('blockdiag-font')
+          args << "-"
+          args
         end
       end
     end


### PR DESCRIPTION
Make it easy to specify what font blockdiag images will use on a per document base.
