### PR TITLE
Allow execution when ENV['PATH'] is not defined

### DIFF
--- a/lib/asciidoctor-diagram/util/which.rb
+++ b/lib/asciidoctor-diagram/util/which.rb
@@ -5,7 +5,7 @@ module Asciidoctor
       def self.which(cmd, options = {})
         exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
 
-        paths = (options[:path] || []) + ENV['PATH'].split(File::PATH_SEPARATOR)
+        paths = (options[:path] || []) + (ENV['PATH'] ? ENV['PATH'].split(File::PATH_SEPARATOR) : [])
         paths.each do |path|
           exts.each { |ext|
             exe = File.join(path, "#{cmd}#{ext}")


### PR DESCRIPTION
The PATH environment variable is not required however this code throws if it is not provided.