### PR TITLE
ADD File Encoding of Java to be UTF-8

### DIFF
--- a/lib/asciidoctor-diagram/util/java_socket.rb
+++ b/lib/asciidoctor-diagram/util/java_socket.rb
@@ -13,6 +13,7 @@ module Asciidoctor
 
         def initialize(java, classpath)
           args = []
+          args << '-Dfile.encoding=UTF-8'
           args << '-Djava.awt.headless=true'
           args << '-cp'
           args << classpath.flatten.map { |jar| ::Asciidoctor::Diagram::Platform.host_os_path(jar).strip }.join(::Asciidoctor::Diagram::Platform.host_os_path_separator)


### PR DESCRIPTION
Without setting the default Java File Encoding it's possible to get broken diagramms when a ascii-diagramm make uses of non-ascii chars like in german language ä, ü, ö, ß ...

Example:

```
.Domäne(en)

[ditaa]
....
+--Java EE Server-----------+
|                           |
|  +--Domäne(n)----------+  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  |                     |  |
|  +---------------------+  |
|                           |
+---------------------------+
....
```

Creates the following broken ditaa-diagramm output:
![diag-a65e3c5c4256ca3719a70dd3989474e8](https://user-images.githubusercontent.com/3332669/27775217-4707ff50-5fa0-11e7-9fc3-3f96099bed45.png)

With this Pull-Request it creates the following correct ditaa-diagramm output:
![diag-a65e3c5c4256ca3719a70dd3989474e8](https://user-images.githubusercontent.com/3332669/27775244-83d08452-5fa0-11e7-86b8-2ed35bf493dd.png)


