### PR TITLE
Fix #154. Don't set nil subs on new blocks

### DIFF
--- a/lib/asciidoctor-diagram/extensions.rb
+++ b/lib/asciidoctor-diagram/extensions.rb
@@ -409,10 +409,9 @@ module Asciidoctor
         protected
         def resolve_diagram_subs
           if @attributes.key? 'subs'
-            subs = @parent_block.resolve_block_subs @attributes['subs'], nil, 'diagram'
-            subs.empty? ? nil : subs
+            @parent_block.resolve_block_subs @attributes['subs'], nil, 'diagram'
           else
-            nil
+            []
           end
         end
 


### PR DESCRIPTION
This is an attempt to fix #154 
I have no idea if I really got it right, but this change makes the AsciidoctorJ tests pass with the latest Asciidoctor 1.5.6.