### PR TITLE
Store resolved command in config

### DIFF
--- a/lib/asciidoctor-diagram/extensions.rb
+++ b/lib/asciidoctor-diagram/extensions.rb
@@ -409,10 +409,9 @@ module Asciidoctor
         protected
         def resolve_diagram_subs
           if @attributes.key? 'subs'
-            subs = @parent_block.resolve_block_subs @attributes['subs'], nil, 'diagram'
-            subs.empty? ? nil : subs
+            @parent_block.resolve_block_subs @attributes['subs'], nil, 'diagram'
           else
-            nil
+            []
           end
         end
 

--- a/lib/asciidoctor-diagram/mermaid/extension.rb
+++ b/lib/asciidoctor-diagram/mermaid/extension.rb
@@ -21,9 +21,9 @@ module Asciidoctor
 
       def mermaid(parent_block, source, format)
         mermaid = which(parent_block, 'mermaid')
-        @is_mermaid_v6 ||= ::Asciidoctor::Diagram::Cli.run(mermaid, '--version').split('.')[0].to_i >= 6
+        config['mermaid>=6'] ||= ::Asciidoctor::Diagram::Cli.run(mermaid, '--version').split('.')[0].to_i >= 6
         # Mermaid >= 6.0.0 requires PhantomJS 2.1; older version required 1.9
-        phantomjs = which(parent_block, 'phantomjs', :alt_attrs => [@is_mermaid_v6 ? 'phantomjs_2' : 'phantomjs_19'])
+        phantomjs = which(parent_block, 'phantomjs', :alt_attrs => [config['mermaid>=6'] ? 'phantomjs_2' : 'phantomjs_19'])
 
         css = source.attr('css', nil, 'mermaid')
         if css

--- a/lib/asciidoctor-diagram/util/which.rb
+++ b/lib/asciidoctor-diagram/util/which.rb
@@ -20,10 +20,10 @@ module Asciidoctor
         attr_names = options[:attrs] || options.fetch(:alt_attrs, []) + [cmd]
         cmd_names = [cmd] + options.fetch(:alt_cmds, [])
 
-        cmd_var = '@' + attr_names[0]
+        cmd_var = 'cmd-' + attr_names[0]
 
-        if instance_variable_defined?(cmd_var)
-          cmd_path = instance_variable_get(cmd_var)
+        if config.key? cmd_var
+          cmd_path = config[cmd_var]
         else
           cmd_path = attr_names.map { |attr_name| parent_block.attr(attr_name, nil, true) }.find { |attr| !attr.nil? }
 
@@ -35,7 +35,7 @@ module Asciidoctor
             cmd_path = cmd_paths.reject { |c| c.nil? }.first
           end
 
-          instance_variable_set(cmd_var, cmd_path)
+          config[cmd_var] = cmd_path
 
           if cmd_path.nil? && options.fetch(:raise_on_error, true)
             raise "Could not find the #{cmd_names.map { |c| "'#{c}'" }.join(', ')} executable in PATH; add it to the PATH or specify its location using the '#{attr_names[0]}' document attribute"


### PR DESCRIPTION
Store the resolved command in config instead of forcing an assign on an instance variable. The only reason this worked before is because it was exploiting a bug in core. Core was freezing the extension class instead of the extension instance. But we should assume that extension instances are frozen. The config map attached to that class, on the other hand, is owned by that instance and open for modification.

I included the commit from #155 to get the tests to pass.