### PR TITLE
Add support for `--title` in syntrax block

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -424,6 +424,7 @@ The attribute name at the block level should be prefixed with the name of the di
 [cols=">,<,<",options="header"]
 |===
 |Name          |Default value   |Description
+|heading       |unspecifed      |Diagram title
 |scale         |1               |A scale factor that is applied to the image.
 |style         |unspecifed      |Path to a style config file to pass to Syntrax.
 |transparent   |false           |Makes the background of the image transparent instead of opaque white.

--- a/lib/asciidoctor-diagram/syntrax/extension.rb
+++ b/lib/asciidoctor-diagram/syntrax/extension.rb
@@ -24,6 +24,11 @@ module Asciidoctor
         generate_file(which(parent, 'syntrax'), 'spec', format.to_s, source.to_s) do |tool_path, input_path, output_path|
           args = [tool_path, '-i', Platform.native_path(input_path), '-o', Platform.native_path(output_path)]
 
+          title = source.attr('heading', nil, inherit_prefix)
+          if title
+            args << '--title' << title
+          end
+
           scale = source.attr('scale', nil, inherit_prefix)
           if scale
             args << '--scale' << scale


### PR DESCRIPTION
Hi,

In LaTeX's `syntax` package I'd use something like this `::=` arrow:

![screenshot-2017-11-2 boost http](https://user-images.githubusercontent.com/865914/32347508-adb552b6-bfef-11e7-9e05-08e0b29905fe.png)

But given syntrax doesn't offer support for custom arrows, I do need to set the diagram title to have a visual separation between the element being described and the rule that defines it. This is the `--title` option.