### PR TITLE
Update the version number for the installation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ by first adding the following entry to your project's [.path]_Gemfile_.
 .Gemfile
 [source,ruby]
 ----
-gem 'asciidoctor-diagram', '~> 1.4.0'
+gem 'asciidoctor-diagram', '~> 1.5.7'
 ----
 
 Then execute `bundle` in the CLI.


### PR DESCRIPTION
From `1.4.0` to `1.5.7`.  
(It took me a while to figure out why I could not use Asciidoctor-diagram with Asciidoctor-revealjs, my problem came from there.)