### PR TITLE
upgrade to plantuml.2019.4

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,9 @@
 Enhancements::
   * Issue #219: Fix compatibility issue with Asciidoctor 2.0
 
+Bug Fixes::
+  * Update PlantUML to 2019.4
+
 == 1.5.15
 
 Enhancements::

--- a/lib/asciidoctor-diagram/plantuml/extension.rb
+++ b/lib/asciidoctor-diagram/plantuml/extension.rb
@@ -12,7 +12,7 @@ module Asciidoctor
 
       JARS = [
           'plantuml-1.3.13.jar',
-          'plantuml-1.2019.4.jar',
+          'plantuml.jar',
           'jlatexmath-minimal-1.0.5.jar',
           'batik-all-1.10.jar'
       ].map do |jar|

--- a/lib/asciidoctor-diagram/plantuml/extension.rb
+++ b/lib/asciidoctor-diagram/plantuml/extension.rb
@@ -12,7 +12,7 @@ module Asciidoctor
 
       JARS = [
           'plantuml-1.3.13.jar',
-          'plantuml.jar',
+          'plantuml-1.2019.4.jar',
           'jlatexmath-minimal-1.0.5.jar',
           'batik-all-1.10.jar'
       ].map do |jar|


### PR DESCRIPTION
I've upgraded plantuml to 2019.4 with a jar I've build locally which has some enhancements in the stdlib like [C4 diagram](https://github.com/RicardoNiepel/C4-PlantUML) support. I could not find an up to date version of the jar.