### PR TITLE
Fix tikz crop issues (prevent extraneous whitespace)

### DIFF
--- a/lib/asciidoctor-diagram/tikz/extension.rb
+++ b/lib/asciidoctor-diagram/tikz/extension.rb
@@ -28,7 +28,7 @@ module Asciidoctor
         end
 
         latex = <<'END'
-\documentclass[border=2bp]{standalone}
+\documentclass[border=2bp, tikz]{standalone}
 \usepackage{tikz}
 \begin{document}
 \begingroup


### PR DESCRIPTION
Without the tikz option, standalone seems to not always properly crop images.  Without the option, my diagram was getting so much extra whitespace on the left that it was at least twice as wide.

This PR should make it so that tikz images don't have extra whitespace around them.