### PR TITLE
Add support for BPMN through bpmn-js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ install:
   - export BLOCKDIAG_FONTPATH=/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf
   - pip install --user -r pip-requirements.txt -c pip-constraints.txt
   - bundle install --path vendor/bundle --jobs=3 --retry=3
+  - npm install -g bpmn-js-cmd
   - npm install -g mermaid.cli
   - npm install -g nomnoml
   - npm install -g state-machine-cat

--- a/lib/asciidoctor-diagram.rb
+++ b/lib/asciidoctor-diagram.rb
@@ -1,5 +1,6 @@
 require_relative 'asciidoctor-diagram/a2s'
 require_relative 'asciidoctor-diagram/blockdiag'
+require_relative 'asciidoctor-diagram/bpmn'
 require_relative 'asciidoctor-diagram/ditaa'
 require_relative 'asciidoctor-diagram/erd'
 require_relative 'asciidoctor-diagram/gnuplot'

--- a/lib/asciidoctor-diagram/bpmn.rb
+++ b/lib/asciidoctor-diagram/bpmn.rb
@@ -1,0 +1,7 @@
+require 'asciidoctor/extensions'
+require_relative 'bpmn/extension'
+
+Asciidoctor::Extensions.register do
+  block Asciidoctor::Diagram::BpmnBlockProcessor, :bpmn
+  block_macro Asciidoctor::Diagram::BpmnBlockMacroProcessor, :bpmn
+end

--- a/lib/asciidoctor-diagram/bpmn/converter.rb
+++ b/lib/asciidoctor-diagram/bpmn/converter.rb
@@ -1,0 +1,62 @@
+require_relative '../diagram_converter'
+require_relative '../util/cli'
+require_relative '../util/cli_generator'
+require_relative '../util/platform'
+
+module Asciidoctor
+  module Diagram
+    # @private
+    class BpmnConverter
+      include DiagramConverter
+      include CliGenerator
+
+
+      def supported_formats
+        [:png, :svg, :pdf, :jpeg]
+      end
+
+      def collect_options(source, name)
+        options = {}
+
+        options[:width] = source.attr('width', nil, name)
+        options[:height] = source.attr('height', nil, name)
+
+        options
+      end
+
+      def convert(source, format, options)
+        opts = {}
+
+        opts[:width] = options[:width]
+
+        bpmnjs = source.find_command('bpmn-js', :raise_on_error => false)
+        opts[:height] = options[:height]
+        opts[:theme] = options[:theme]
+        config = options[:config]
+        if config
+          opts[:config] = source.resolve_path(config)
+        end
+        run_bpmnjs(bpmnjs, source, format, opts)
+      end
+
+      private
+
+      def run_bpmnjs(bpmnjs, source, format, options = {})
+        generate_file(bpmnjs, 'bpmn', format.to_s, source.to_s) do |tool_path, input_path, output_path|
+          args = [tool_path, Platform.native_path(input_path), '-o', Platform.native_path(output_path), '-t', format.to_s]
+
+
+          if options[:width]
+            args << '--width' << options[:width]
+          end
+
+          if options[:height]
+            args << '--height' << options[:height]
+          end
+
+          args
+        end
+      end
+    end
+  end
+end

--- a/lib/asciidoctor-diagram/bpmn/extension.rb
+++ b/lib/asciidoctor-diagram/bpmn/extension.rb
@@ -1,0 +1,14 @@
+require_relative 'converter'
+require_relative '../diagram_processor'
+
+module Asciidoctor
+  module Diagram
+    class BpmnBlockProcessor < DiagramBlockProcessor
+      use_converter BpmnConverter
+    end
+
+    class BpmnBlockMacroProcessor < DiagramBlockMacroProcessor
+      use_converter BpmnConverter
+    end
+  end
+end

--- a/spec/bpmn-example.xml
+++ b/spec/bpmn-example.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0zt4mn9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="5.1.2">
+  <bpmn:process id="Process_081h9u7" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_00w25dz" name="Start">
+      <bpmn:outgoing>SequenceFlow_11u0n1f</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_0yx8j7s" name="Task">
+      <bpmn:incoming>SequenceFlow_11u0n1f</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_104th5x</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_11u0n1f" sourceRef="StartEvent_00w25dz" targetRef="Task_0yx8j7s" />
+    <bpmn:endEvent id="EndEvent_0jxehtp" name="End">
+      <bpmn:incoming>SequenceFlow_104th5x</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_104th5x" sourceRef="Task_0yx8j7s" targetRef="EndEvent_0jxehtp" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_081h9u7">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_00w25dz">
+        <dc:Bounds x="156" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="162" y="124" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0yx8j7s_di" bpmnElement="Task_0yx8j7s">
+        <dc:Bounds x="250" y="59" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_11u0n1f_di" bpmnElement="SequenceFlow_11u0n1f">
+        <di:waypoint x="192" y="99" />
+        <di:waypoint x="250" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0jxehtp_di" bpmnElement="EndEvent_0jxehtp">
+        <dc:Bounds x="412" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="420" y="124" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_104th5x_di" bpmnElement="SequenceFlow_104th5x">
+        <di:waypoint x="350" y="99" />
+        <di:waypoint x="412" y="99" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spec/bpmn_spec.rb
+++ b/spec/bpmn_spec.rb
@@ -1,0 +1,96 @@
+require_relative 'test_helper'
+
+describe Asciidoctor::Diagram::BpmnBlockMacroProcessor do
+  it "should generate SVG images when format is set to 'svg'" do
+    FileUtils.cp(
+        File.expand_path('bpmn-example.xml', File.dirname(__FILE__)),
+        File.expand_path('bpmn-example.xml', Dir.getwd)
+    )
+
+    doc = <<-eos
+= Hello, BPMN!
+Doc Writer <doc@example.com>
+
+== First Section
+
+bpmn::bpmn-example.xml[format="svg"]
+    eos
+
+    d = load_asciidoc doc
+    expect(d).to_not be_nil
+
+    b = d.find { |bl| bl.context == :image }
+    expect(b).to_not be_nil
+
+    expect(b.content_model).to eq :empty
+
+    target = b.attributes['target']
+    expect(target).to_not be_nil
+    expect(target).to match(/\.svg/)
+    expect(File.exist?(target)).to be true
+
+    expect(b.attributes['width']).to_not be_nil
+    expect(b.attributes['height']).to_not be_nil
+  end
+
+  it "should generate PNG images when format is set to 'png'" do
+    FileUtils.cp(
+        File.expand_path('bpmn-example.xml', File.dirname(__FILE__)),
+        File.expand_path('bpmn-example.xml', Dir.getwd)
+    )
+
+    doc = <<-eos
+= Hello, BPMN!
+Doc Writer <doc@example.com>
+
+== First Section
+
+bpmn::bpmn-example.xml[format="png"]
+    eos
+
+    d = load_asciidoc doc
+    expect(d).to_not be_nil
+
+    b = d.find { |bl| bl.context == :image }
+    expect(b).to_not be_nil
+
+    expect(b.content_model).to eq :empty
+
+    target = b.attributes['target']
+    expect(target).to_not be_nil
+    expect(target).to match(/\.png$/)
+    expect(File.exist?(target)).to be true
+
+    expect(b.attributes['width']).to_not be_nil
+    expect(b.attributes['height']).to_not be_nil
+  end
+
+  it "should generate PDF images when format is set to 'pdf'" do
+    FileUtils.cp(
+        File.expand_path('bpmn-example.xml', File.dirname(__FILE__)),
+        File.expand_path('bpmn-example.xml', Dir.getwd)
+    )
+
+    doc = <<-eos
+= Hello, BPMN!
+Doc Writer <doc@example.com>
+
+== First Section
+
+bpmn::bpmn-example.xml[format="pdf"]
+    eos
+
+    d = load_asciidoc doc
+    expect(d).to_not be_nil
+
+    b = d.find { |bl| bl.context == :image }
+    expect(b).to_not be_nil
+
+    expect(b.content_model).to eq :empty
+
+    target = b.attributes['target']
+    expect(target).to_not be_nil
+    expect(target).to match(/\.pdf$/)
+    expect(File.exist?(target)).to be true
+  end
+end


### PR DESCRIPTION
This adds support for BPMN-Diagrams through [BPMN-JS](https://bpmn.io/toolkit/bpmn-js/) and a [command line wrapper](https://www.npmjs.com/package/bpmn-js-cmd). It uses puppeteer to do the rendering stuff.

I know XML isn't a format well suited for embedding in documents. But I write a lot of documentation including BPMN-Processes and it would be cool if I could directly reference them in the documentation from the source files instead of having to rerender them to SVG every time somebody makes a change. The macro-form would be perfect here and the preferred way of using this extension. 

BPMN-JS is a battle-tested library and well maintained.