### PR TITLE
#270 Allow setting options for svgbob

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -497,6 +497,17 @@ The attribute name at the block level should be prefixed with the name of the di
 |engine        |unspecified     |The layout engine to use. One of `dot`, `circo`, `fdp`, `neato`, `osage`, or `twopi`
 |===
 
+==== svgbob
+
+[cols=">,<,<",options="header"]
+|===
+|Name          |Default value   |Description
+|font-family   |arial           |text will be rendered with this font
+|font-size     |14              |text will be rendered with this font size
+|scale         |1               |scale the entire svg (dimensions, font size, stroke width) by this factor
+|stroke-width  |2               |stroke width for all lines
+|===
+
 ==== Syntrax
 
 [cols=">,<,<",options="header"]

--- a/lib/asciidoctor-diagram/svgbob/converter.rb
+++ b/lib/asciidoctor-diagram/svgbob/converter.rb
@@ -14,10 +14,34 @@ module Asciidoctor
         [:svg]
       end
 
+      OPTIONS = {
+          :font_family => lambda { |o, v| o << '--font-family' << v if v },
+          :font_size => lambda { |o, v| o << '--font-size' << v if v },
+          :stroke_width => lambda { |o, v| o << '--stroke-width' << v if v },
+          :scale => lambda { |o, v| o << '--scale' << v if v }
+      }
+
+      def collect_options(source, name)
+        options = {}
+
+        OPTIONS.keys.each do |option|
+          attr_name = option.to_s.tr('_', '-')
+          options[option] = source.attr(attr_name, nil, name) || source.attr(attr_name, nil, 'svgbob-option')
+        end
+
+        options
+      end
+
 
       def convert(source, format, options)
+
+        flags = []
+        options.each do |option, value|
+          OPTIONS[option].call(flags, value)
+        end
+        
         generate_stdin(source.find_command('svgbob'), format.to_s, source.to_s) do |tool_path, output_path|
-          [tool_path, '-o', Platform.native_path(output_path)]
+          ([tool_path, '-o', Platform.native_path(output_path)] + flags)
         end
       end
     end


### PR DESCRIPTION
issue #270: svgbob is currently not one of the diagram types where options are supported. This pull request adds that in. 

Documentation is from --help text of svgbob. 