### PR TITLE
Fix link to svg-bytefield in README #276

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ The following diagram types and output formats are available:
 |{uri-actdiag}[actdiag]      |       |{check}|{check}|{check}|
 |{uri-blockdiag}[blockdiag]  |       |{check}|{check}|{check}|
 |{uri-bpmn}[bpmn]            |       |{check}|{check}|{check}|
-|{uri-bytefield}{bytefield]  |       |       |       |{check}|
+|{uri-bytefield}[bytefield]  |       |       |       |{check}|
 |{uri-ditaa}[ditaa]          |       |       |{check}|{check}|
 |{uri-erd}[erd]              |       |       |{check}|{check}|
 |{uri-gnuplot}[gnuplot]      |{check}|       |{check}|{check}|{check}


### PR DESCRIPTION
I was going to try and see if I could figure out how to update the version of `bytefield-svg` that you pull in, because I released a bunch of nice new features this weekend, but it looks like you always pull in the most recent one? In any case, my tests of the new features are working in my clone of asciidoctor-diagram.

Here is a tweak to the README that I mentioned in the issue, anyway.