### PR TITLE
Gives access to the preamble section in the generated LaTeX file. 

### DIFF
--- a/lib/asciidoctor-diagram/tikz/converter.rb
+++ b/lib/asciidoctor-diagram/tikz/converter.rb
@@ -13,6 +13,11 @@ module Asciidoctor
         [:pdf, :svg]
       end
 
+      def collect_options(source)
+        {
+            :preamble => source.attr('preamble')
+        }
+      end
 
       def convert(source, format, options)
         latexpath = source.find_command('pdflatex')
@@ -23,14 +28,28 @@ module Asciidoctor
           svgpath = nil
         end
 
+        preamble = ""
+        body = ""
+        sep = "~~~~\n"
+        if options[:preamble] == "true" and source.to_s.include?(sep)
+          parts = source.to_s.split(sep)
+          preamble = parts[0]
+          body = parts[1]
+        else
+          body = source.to_s
+        end
+
         latex = <<'END'
 \documentclass[border=2bp, tikz]{standalone}
 \usepackage{tikz}
+END
+        latex << preamble
+        latex << <<'END'
 \begin{document}
 \begingroup
 \tikzset{every picture/.style={scale=1}}
 END
-        latex << source.to_s
+        latex << body
         latex << <<'END'
 \endgroup
 \end{document}


### PR DESCRIPTION
This feature was motived by a need to use TikZ in conjunction with the `tkz-euclide` package. But more broadly, gives you access to the LaTeX preamble section, which therein gives you access to any LaTeX/TikZ package.

# Example

## Code
```asciidoc
= Hello World

[tikz,"image2",svg, preamble=true]
----
\usepackage{tkz-euclide}
\usepackage{etoolbox}
\usepackage{MnSymbol}
% \usetkzobj{all}
\usetikzlibrary{angles,patterns,calc}
\usepackage[most]{tcolorbox}
\usepackage{pgfplots}
\pgfplotsset{compat=1.7}

~~~~
\begin{tikzpicture}
\tikzset{>=stealth}
% draw axises and labels. We store a single coordinate to have the
% direction of the x axis
\draw[->] (-4,0) -- ++(8,0) coordinate (X) node[below] {$x$};
\draw[->] (0,-4) -- ++(0,8) node[left] {$y$};

\newcommand\CircleRadius{3cm}
\draw (0,0) circle (\CircleRadius);
% special method of noting the position of a point
\coordinate (P) at (-495:\CircleRadius);

\draw[thick]
(0,0)
coordinate (O) % store origin
node[] {} % label
--
node[below left, pos=1] {$P(-\frac{\sqrt{2}}{2}, -\frac{\sqrt{2}}{2})$} % some labels
node[below right, midway] {$r$}
(P)
--
node[midway,left] {$y$}
(P |- O) coordinate (Px) % projection onto horizontal line through
                            % O, saved for later
--
node[midway, below] {$x$}
cycle % closed path

% pic trick is from the angles library, requires the three points of
% the marked angle to be named

pic [] {angle=X--O--P};
\draw[->,red] (5mm, 0mm) arc (0:-495:5mm) node[midway,xshift=-4mm,yshift=3.5mm] {$-495^\circ$};
% right angle marker
\draw ($(Px)+(0.3, 0)$) -- ++(0, -0.3) -- ++(-0.3,0);
\end{tikzpicture}
----
```

As you can see, the `~~~~` token separates the two sections (activated by the `preamble=true` option). 

## Result
<img width="1379" alt="Screen Shot 2020-09-30 at 6 51 45 PM" src="https://user-images.githubusercontent.com/2118601/94754830-98747200-034f-11eb-9779-024699c849dc.png">

