### PR TITLE
speedup CI workflow

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -12,56 +12,61 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.5, 2.6, 2.7, jruby, truffleruby]
+        ruby: [truffleruby, jruby, 2.7, 2.6, 2.5]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Packages
         run: |
-          sudo apt-get install -qq haveged
-          sudo apt-get install -qq gconf-service
-          sudo apt-get install -qq libasound2
-          sudo apt-get install -qq libatk1.0-0
-          sudo apt-get install -qq libc6
-          sudo apt-get install -qq libcairo2
-          sudo apt-get install -qq libcairo-gobject2
-          sudo apt-get install -qq libcups2
-          sudo apt-get install -qq libdbus-1-3
-          sudo apt-get install -qq libexpat1
-          sudo apt-get install -qq libfontconfig1
-          sudo apt-get install -qq libgcc1
-          sudo apt-get install -qq libgconf-2-4
-          sudo apt-get install -qq libgdk-pixbuf2.0-0
-          sudo apt-get install -qq libglib2.0-0
-          sudo apt-get install -qq libgirepository1.0-dev
-          sudo apt-get install -qq libgtk-3-0
-          sudo apt-get install -qq libnspr4
-          sudo apt-get install -qq libpango-1.0-0
-          sudo apt-get install -qq libpangocairo-1.0-0
-          sudo apt-get install -qq gir1.2-pango-1.0
-          sudo apt-get install -qq libstdc++6
-          sudo apt-get install -qq libx11-6
-          sudo apt-get install -qq libx11-xcb1
-          sudo apt-get install -qq libxcb1
-          sudo apt-get install -qq libxcomposite1
-          sudo apt-get install -qq libxcursor1
-          sudo apt-get install -qq libxdamage1
-          sudo apt-get install -qq libxext6
-          sudo apt-get install -qq libxfixes3
-          sudo apt-get install -qq libxi6
-          sudo apt-get install -qq libxrandr2
-          sudo apt-get install -qq libxrender1
-          sudo apt-get install -qq libxss1
-          sudo apt-get install -qq libxtst6
-          sudo apt-get install -qq ca-certificates
-          sudo apt-get install -qq fonts-liberation
-          sudo apt-get install -qq libappindicator1
-          sudo apt-get install -qq libnss3
-          sudo apt-get install -qq lsb-release
-          sudo apt-get install -qq xdg-utils
-          sudo apt-get install -qq curl
-          sudo apt-get install -qq ttf-dejavu
+          sudo apt-get install -qq \
+          haveged \
+          gconf-service \
+          libasound2 \
+          libatk1.0-0 \
+          libc6 \
+          libcairo2 \
+          libcairo-gobject2 \
+          libcups2 \
+          libdbus-1-3 \
+          libexpat1 \
+          libfontconfig1 \
+          libgcc1 \
+          libgconf-2-4 \
+          libgdk-pixbuf2.0-0 \
+          libglib2.0-0 \
+          libgirepository1.0-dev \
+          libgtk-3-0 \
+          libnspr4 \
+          libpango-1.0-0 \
+          libpangocairo-1.0-0 \
+          gir1.2-pango-1.0 \
+          libstdc++6 \
+          libx11-6 \
+          libx11-xcb1 \
+          libxcb1 \
+          libxcomposite1 \
+          libxcursor1 \
+          libxdamage1 \
+          libxext6 \
+          libxfixes3 \
+          libxi6 \
+          libxrandr2 \
+          libxrender1 \
+          libxss1 \
+          libxtst6 \
+          ca-certificates \
+          fonts-liberation \
+          libappindicator1 \
+          libnss3 \
+          lsb-release \
+          xdg-utils \
+          curl \
+          ttf-dejavu \
+          graphviz \
+          lilypond \
+          gnuplot \
+          mscgen
       - name: Setup Node
         uses: actions/setup-node@v1
       - name: Setup Ruby
@@ -83,10 +88,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Install Graphviz
-        run: sudo apt-get install -qq graphviz
-      - name: Install Lilypond
-        run: sudo apt-get install -qq lilypond
       - name: Install BPNM-JS
         run: npm install -g bpmn-js-cmd
       - name: Install Mermaid
@@ -102,8 +103,6 @@ jobs:
           install-peerdeps -g vega-lite
       - name: Install Wavedrom
         run: npm install -g wavedrom-cli
-      - name: Install Gnuplot
-        run: sudo apt-get install -qq gnuplot
       - name: Install UMLet
         run: |
           curl -s -O http://www.umlet.com/umlet_14_2/umlet-standalone-14.2.zip
@@ -111,8 +110,6 @@ jobs:
           cp Umlet/umlet.sh Umlet/umlet
           chmod +x Umlet/umlet
           echo "$PWD/Umlet" >> $GITHUB_PATH
-      - name: Install MSCgen
-        run: sudo apt-get install -qq mscgen
       - name: Install Blockdiag
         run: pip install blockdiag[pdf] actdiag seqdiag nwdiag[pdf]
       - name: Install Syntrax


### PR DESCRIPTION
1. Reorder Rubies so that slow ones start first. The benefit of this change will be visible on builds where there was not enough runners to run all parallel tasks at once.
2. Combine apt-get install into a single command

Before: around [9min](https://github.com/asciidoctor/asciidoctor-diagram/actions?query=workflow%3A%22Linux+unit+tests%22+branch%3Amaster) for full CI run
After: around [8min](https://github.com/slonopotamus/asciidoctor-diagram/actions/runs/359847461) for full CI run.