### PR TITLE
run apt-get update before attempting to install packages on GitHub Actions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Packages
         run: |
+          sudo apt-get update
           sudo apt-get install -qq haveged
           sudo apt-get install -qq gconf-service
           sudo apt-get install -qq libasound2


### PR DESCRIPTION
This commit fixes [build failures](https://github.com/asciidoctor/asciidoctor-diagram/actions/runs/389348241) on `master` branch.