### PR TITLE
Add links to jsyntrax project

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,7 +5,7 @@ include::partial$uris.adoc[]
 
 Asciidoctor Diagram is a set of Asciidoctor extensions that enable you to add diagrams, which you describe using plain text, to your AsciiDoc document.
 
-The extensions supports the {uri-a2s}[AsciiToSVG], BlockDiag ({uri-blockdiag}[BlockDiag], {uri-seqdiag}[SeqDiag], {uri-actdiag}[ActDiag], {uri-nwdiag}[NwDiag]), {uri-bytefield}[Bytefield-SVG], {uri-ditaa}[Ditaa], {uri-dpic}[dpic], {uri-erd}[Erd], {uri-gnuplot}[Gnuplot], {uri-dot}[GraphViz], {uri-mermaid}[Mermaid], {uri-mscgen}[Msc], {uri-nomnoml}[Nomnoml], {uri-pikchr}[Pikchr], {uri-plantuml}[PlantUML], {uri-shaape}[Shaape], {uri-smcat}[State Machine Cat], {uri-svgbob}[SvgBob], {uri-symbolator}[Symbolator], {uri-syntrax}[Syntrax], {uri-umlet}[UMLet], {uri-vega}[Vega], {uri-vegalite}[Vega-Lite] and {uri-wavedrom}[WaveDrom] syntax.
+The extensions supports the {uri-a2s}[AsciiToSVG], BlockDiag ({uri-blockdiag}[BlockDiag], {uri-seqdiag}[SeqDiag], {uri-actdiag}[ActDiag], {uri-nwdiag}[NwDiag]), {uri-bytefield}[Bytefield-SVG], {uri-ditaa}[Ditaa], {uri-dpic}[dpic], {uri-erd}[Erd], {uri-gnuplot}[Gnuplot], {uri-dot}[GraphViz], {uri-mermaid}[Mermaid], {uri-mscgen}[Msc], {uri-nomnoml}[Nomnoml], {uri-pikchr}[Pikchr], {uri-plantuml}[PlantUML], {uri-shaape}[Shaape], {uri-smcat}[State Machine Cat], {uri-svgbob}[SvgBob], {uri-symbolator}[Symbolator], {uri-syntrax}[Syntrax]/{uri-jsyntrax}[JSyntrax], {uri-umlet}[UMLet], {uri-vega}[Vega], {uri-vegalite}[Vega-Lite] and {uri-wavedrom}[WaveDrom] syntax.
 
 Each extension runs the diagram processor to generate an SVG, PNG, or TXT file from the input text.
 The generated file is then inserted into your converted document.

--- a/docs/modules/ROOT/partials/advanced.adoc
+++ b/docs/modules/ROOT/partials/advanced.adoc
@@ -93,7 +93,7 @@ The following table lists the tools that are required for each diagram type, the
    |smcat        |{uri-smcat}[State Machine Cat]                                        |`smcat`
    |svgbob       |{uri-svgbob}[SvgBob]                                                  |`svgbob`
    |symbolator   |{uri-symbolator}[Symbolator]                                          |`symbolator`
-   |syntrax      |{uri-syntrax}[Syntrax]                                                |`syntrax`
+   |syntrax      |{uri-syntrax}[Syntrax]/{uri-jsyntrax}[JSyntrax]                       |`syntrax`
    |tikz         |A TeX distribution that supports {uri-tikz}[TikZ]                     |`pdflatex` and `pdf2svg`
    |umlet        |{uri-umlet}[Umlet]                                                    |`umlet`
    |vega         |{uri-vega}[vg2png] and/or {uri-vega}[vg2png]                          |`vg2png` and `vg2svg`

--- a/docs/modules/ROOT/partials/create_diagram.adoc
+++ b/docs/modules/ROOT/partials/create_diagram.adoc
@@ -20,38 +20,39 @@ The following diagram types and output formats are available:
 
 [cols=">,5*^",options="header"]
 |===
-|Diagram Type                |gif    |pdf    |png    |svg    |txt
-|{uri-a2s}[a2s]              |       |       |       |{check}|
-|{uri-actdiag}[actdiag]      |       |{check}|{check}|{check}|
-|{uri-blockdiag}[blockdiag]  |       |{check}|{check}|{check}|
-|{uri-bpmn}[bpmn]            |       |{check}|{check}|{check}|
-|{uri-bytefield}[bytefield]  |       |       |       |{check}|
-|{uri-diagrams}[diagrams]    |       |{check}|{check}|{check}|
-|{uri-ditaa}[ditaa]          |       |       |{check}|{check}|
-|{uri-dpic}[dpic]            |       |       |       |{check}|
-|{uri-erd}[erd]              |       |       |{check}|{check}|
-|{uri-gnuplot}[gnuplot]      |{check}|       |{check}|{check}|{check}
-|{uri-dot}[graphviz]         |       |{check}|{check}|{check}|
-|<<meme,meme>>               |{check}|       |{check}|       |
-|{uri-mermaid}[mermaid]      |       |{check}|{check}|{check}|
-|{uri-mscgen}[msc]           |       |       |{check}|{check}|
-|{uri-nomnoml}[nomnoml]      |       |       |       |{check}|
-|{uri-nwdiag}[nwdiag]        |       |{check}|{check}|{check}|
-|{uri-packetdiag}[packetdiag]|       |{check}|{check}|{check}|
-|{uri-pikchr}[pikchr]        |       |       |       |{check}|
-|{uri-plantuml}[plantuml]    |       |       |{check}|{check}|{check}
-|{uri-rackdiag}[rackdiag]    |       |{check}|{check}|{check}|
-|{uri-seqdiag}[seqdiag]      |       |{check}|{check}|{check}|
-|{uri-shaape}[shaape]        |       |       |{check}|{check}|
-|{uri-smcat}[smcat]          |       |       |       |{check}|
-|{uri-svgbob}[svgbob]        |       |       |       |{check}|
-|{uri-symbolator}[symbolator]|       |{check}|{check}|{check}|
-|{uri-syntrax}[syntrax]      |       |{check}|{check}|{check}|
-|{uri-tikz}[tikz]            |       |{check}|       |{check}|
-|{uri-umlet}[umlet]          |{check}|{check}|{check}|{check}|
-|{uri-vega}[vega]            |       |       |{check}|{check}|
-|{uri-vegalite}[vegalite]    |       |       |{check}|{check}|
-|{uri-wavedrom}[wavedrom]    |       |       |{check}|{check}|
+|Diagram Type                      |gif    |pdf    |png    |svg    |txt
+|{uri-a2s}[a2s]                    |       |       |       |{check}|
+|{uri-actdiag}[actdiag]            |       |{check}|{check}|{check}|
+|{uri-blockdiag}[blockdiag]        |       |{check}|{check}|{check}|
+|{uri-bpmn}[bpmn]                  |       |{check}|{check}|{check}|
+|{uri-bytefield}[bytefield]        |       |       |       |{check}|
+|{uri-diagrams}[diagrams]          |       |{check}|{check}|{check}|
+|{uri-ditaa}[ditaa]                |       |       |{check}|{check}|
+|{uri-dpic}[dpic]                  |       |       |       |{check}|
+|{uri-erd}[erd]                    |       |       |{check}|{check}|
+|{uri-gnuplot}[gnuplot]            |{check}|       |{check}|{check}|{check}
+|{uri-dot}[graphviz]               |       |{check}|{check}|{check}|
+|<<meme,meme>>                     |{check}|       |{check}|       |
+|{uri-mermaid}[mermaid]            |       |{check}|{check}|{check}|
+|{uri-mscgen}[msc]                 |       |       |{check}|{check}|
+|{uri-nomnoml}[nomnoml]            |       |       |       |{check}|
+|{uri-nwdiag}[nwdiag]              |       |{check}|{check}|{check}|
+|{uri-packetdiag}[packetdiag]      |       |{check}|{check}|{check}|
+|{uri-pikchr}[pikchr]              |       |       |       |{check}|
+|{uri-plantuml}[plantuml]          |       |       |{check}|{check}|{check}
+|{uri-rackdiag}[rackdiag]          |       |{check}|{check}|{check}|
+|{uri-seqdiag}[seqdiag]            |       |{check}|{check}|{check}|
+|{uri-shaape}[shaape]              |       |       |{check}|{check}|
+|{uri-smcat}[smcat]                |       |       |       |{check}|
+|{uri-svgbob}[svgbob]              |       |       |       |{check}|
+|{uri-symbolator}[symbolator]      |       |{check}|{check}|{check}|
+|{uri-syntrax}[syntrax] (Syntrax)  |       |{check}|{check}|{check}|
+|{uri-jsyntrax}[syntrax] (JSyntrax)|       |       |{check}|{check}|
+|{uri-tikz}[tikz]                  |       |{check}|       |{check}|
+|{uri-umlet}[umlet]                |{check}|{check}|{check}|{check}|
+|{uri-vega}[vega]                  |       |       |{check}|{check}|
+|{uri-vegalite}[vegalite]          |       |       |{check}|{check}|
+|{uri-wavedrom}[wavedrom]          |       |       |{check}|{check}|
 |===
 
 :!check:

--- a/docs/modules/ROOT/partials/uris.adoc
+++ b/docs/modules/ROOT/partials/uris.adoc
@@ -31,6 +31,7 @@
 :uri-svgbob: https://github.com/ivanceras/svgbobrus
 :uri-symbolator: https://github.com/kevinpt/symbolator
 :uri-syntrax: https://kevinpt.github.io/syntrax/
+:uri-jsyntrax: https://atp-mipt.github.io/jsyntrax/
 :uri-tikz: https://github.com/pgf-tikz/pgf
 :uri-umlet: http://www.umlet.com/
 :uri-vega: https://vega.github.io/vega/


### PR DESCRIPTION
This is a proposal to add links to [`jsyntrax`](https://github.com/atp-mipt/jsyntrax) project besides original [`syntrax`](https://github.com/kevinpt/syntrax).

Some reasons:

* `jsyntrax` has the same command line arguments and thus it can be used as a replacement for `syntrax`, particularly in Asciidoctor diagrams.
* Unlike `syntrax` that requires a number of libraries that are tricky to install outside Linux,  `jsyntrax` is a Java program which can run anywhere Java can run.
* `jsyntrax`'s [own documentation](https://atp-mipt.github.io/jsyntrax/) is built with Asciidoctor-diagram.
* [Here](https://courseorchestra.github.io/celesta/en/#CelestaSQL) is another example of documentation built with `jsyntrax`+Asciidoctor-diagram.