### PR TITLE
handle errors in converters when wrapping the source

### DIFF
--- a/spec/plantuml_spec.rb
+++ b/spec/plantuml_spec.rb
@@ -190,6 +190,29 @@ Doc Writer <doc@example.com>
     expect(b.attributes['height']).to_not be_nil
   end
 
+  it "should handle syntax errors gracefully" do
+    doc = <<-eos
+[plantuml]
+----
+@startuml
+xxx
+@enduml
+----
+    eos
+
+    options = {}
+    options[:attributes] = {}
+    options[:attributes]['diagram-on-error'] = 'log'
+
+    d = load_asciidoc doc, options
+    expect(d).to_not be_nil
+
+    b = d.find { |bl| bl.context == :listing }
+    expect(b).to_not be_nil
+
+    expect(b.source).to include 'Failed to generate image'
+  end
+
   it 'should use plantuml configuration when specified as a document attribute' do
     doc = <<-eos
 = Hello, PlantUML!

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -65,7 +65,9 @@ module Asciidoctor
           options[:attributes]['seqdiag-fontpath'] = fontpath
         end
 
-        options[:attributes]['diagram-on-error'] = 'abort'
+        unless options[:attributes]['diagram-on-error']
+          options[:attributes]['diagram-on-error'] = 'abort'
+        end
 
         ::Asciidoctor.load(StringIO.new(source), options.merge({:trace => true}))
       end


### PR DESCRIPTION
This moves wrap_source() inside the begin/rescue block so that exceptions can be shown in the additional source block in the rendered document.

fix #355