### PR TITLE
Update the git:// protocol to use HTTPS instead

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -109,7 +109,7 @@ jobs:
         run: npm install -g bytefield-svg
       - name: Install ERD
         run: |
-          git clone git://github.com/BurntSushi/erd
+          git clone https://github.com/BurntSushi/erd
           cd erd
           stack install
           echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm install -g bytefield-svg
       - name: Install ERD
         run: |
-          git clone git://github.com/BurntSushi/erd
+          git clone https://github.com/BurntSushi/erd
           cd erd
           stack install
           echo "$HOME/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Description

GitHub has recently dropped the support for the `git://` protocol. Running `git clone git://github.com/BurntSushi/erd` yields this:

```sh
Cloning into 'erd'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

More background information on this blog: https://github.blog/2021-09-01-improving-git-protocol-security-github/

This PR updates the `git://` protocol to use `HTTPS` instead