### PR TITLE
Update PlantUML to 1.2022.12

### DIFF
--- a/deps/plantuml/asciidoctor-diagram-plantuml.gemspec
+++ b/deps/plantuml/asciidoctor-diagram-plantuml.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'asciidoctor-diagram-plantuml'
-  s.version       = '1.2022.5'
+  s.version       = '1.2022.12'
   s.authors       = ['Pepijn Van Eeckhoudt']
   s.email         = ['pepijn@vaneeckhoudt.net']
   s.description   = %q{PlantUML JAR files wrapped in a Ruby gem}


### PR DESCRIPTION
Just updating PlantUML to 1.2022.12 as it adds some new features I would like to use.

Used the ~~MIT~~ ASL license version from the [download page](https://plantuml.com/download).