### PR TITLE
#437 Use diagram source base dir as working directory for all exec'd processes

### DIFF
--- a/lib/asciidoctor-diagram/a2s/converter.rb
+++ b/lib/asciidoctor-diagram/a2s/converter.rb
@@ -49,7 +49,10 @@ module Asciidoctor
             args << '-f' << font
           end
 
-          args
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
 

--- a/lib/asciidoctor-diagram/blockdiag/converter.rb
+++ b/lib/asciidoctor-diagram/blockdiag/converter.rb
@@ -25,7 +25,11 @@ module Asciidoctor
             args = [tool_path, '-a', '-o', Platform.native_path(output_path), "-T#{format.to_s}"]
             args << "-f#{Platform.native_path(font_path)}" if font_path
             args << '-'
-            args
+
+            {
+              :args => args,
+              :chdir => source.base_dir
+            }
           end
         end
       end

--- a/lib/asciidoctor-diagram/bpmn/converter.rb
+++ b/lib/asciidoctor-diagram/bpmn/converter.rb
@@ -54,7 +54,10 @@ module Asciidoctor
             args << '--height' << options[:height]
           end
 
-          args
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/bytefield/converter.rb
+++ b/lib/asciidoctor-diagram/bytefield/converter.rb
@@ -18,7 +18,10 @@ module Asciidoctor
         bytefield_path = source.find_command('bytefield-svg')
 
         generate_stdin(bytefield_path, format.to_s, source.to_s) do |tool_path, output_path|
-          [tool_path, "--output", Platform.native_path(output_path)]
+          {
+            :args => [tool_path, "--output", Platform.native_path(output_path)],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/dbml/converter.rb
+++ b/lib/asciidoctor-diagram/dbml/converter.rb
@@ -15,7 +15,12 @@ module Asciidoctor
       end
 
       def convert(source, format, options)
-        generate_stdin_stdout(source.find_command('dbml-renderer'), source.code)
+        generate_stdin_stdout(source.find_command('dbml-renderer'), source.code) do |tool|
+          {
+            :args => [tool],
+            :chdir => source.base_dir
+          }
+        end
       end
     end
   end

--- a/lib/asciidoctor-diagram/diagrams/converter.rb
+++ b/lib/asciidoctor-diagram/diagrams/converter.rb
@@ -38,7 +38,10 @@ module Asciidoctor
         begin
           target_file.close
           generate_stdin_file(python_path, code, target_file.path + ".#{format}") do |tool|
-            [tool, '-']
+            {
+              :args => [tool, '-'],
+              :chdir => source.base_dir
+            }
           end
         ensure
           target_file.unlink

--- a/lib/asciidoctor-diagram/dpic/converter.rb
+++ b/lib/asciidoctor-diagram/dpic/converter.rb
@@ -22,7 +22,10 @@ module Asciidoctor
         code << "\n.PE" unless code.start_with?("\n.PE")
 
         generate_file_stdout(dpic_path, format.to_s, code) do |tool_path, input_path|
-          [tool_path, "-v", "-z", input_path]
+          {
+            :args => [tool_path, "-v", "-z", input_path],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/erd/converter.rb
+++ b/lib/asciidoctor-diagram/erd/converter.rb
@@ -23,7 +23,10 @@ module Asciidoctor
         end
 
         generate_stdin(dot_path, format.to_s, dot_code) do |tool_path, output_path|
-          [tool_path, "-o#{Platform.native_path(output_path)}", "-T#{format.to_s}"]
+          {
+            :args => [tool_path, "-o#{Platform.native_path(output_path)}", "-T#{format.to_s}"],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/gnuplot/converter.rb
+++ b/lib/asciidoctor-diagram/gnuplot/converter.rb
@@ -56,7 +56,12 @@ module Asciidoctor
         code << "\n"
         code << source.to_s
 
-        generate_stdin_stdout(source.find_command('gnuplot'), code)
+        generate_stdin_stdout(source.find_command('gnuplot'), code) do |tool|
+          {
+            :args => [tool],
+            :chdir => source.base_dir
+          }
+        end
       end
     end
   end

--- a/lib/asciidoctor-diagram/graphviz/converter.rb
+++ b/lib/asciidoctor-diagram/graphviz/converter.rb
@@ -24,7 +24,10 @@ module Asciidoctor
           layout = options[:layout]
           args << "-K#{layout}" if layout
 
-          args
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/graphviz_py/converter.rb
+++ b/lib/asciidoctor-diagram/graphviz_py/converter.rb
@@ -34,7 +34,10 @@ module Asciidoctor
             args << argument
           end
 
-          args
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/http/converter.rb
+++ b/lib/asciidoctor-diagram/http/converter.rb
@@ -1,5 +1,4 @@
 require_relative '../diagram_converter'
-require_relative '../util/cli_generator'
 require_relative '../util/platform'
 
 require 'base64'

--- a/lib/asciidoctor-diagram/lilypond/converter.rb
+++ b/lib/asciidoctor-diagram/lilypond/converter.rb
@@ -55,7 +55,8 @@ module Asciidoctor
 
           {
               :args => args,
-              :out_file => "#{output_path}.cropped.#{format.to_s}"
+              :out_file => "#{output_path}.cropped.#{format.to_s}",
+              :chdir => source.base_dir
           }
         end        
       end

--- a/lib/asciidoctor-diagram/mermaid/converter.rb
+++ b/lib/asciidoctor-diagram/mermaid/converter.rb
@@ -164,7 +164,8 @@ module Asciidoctor
 
           {
               :args => args,
-              :env => {'NODE_OPTIONS' => '--unhandled-rejections=strict'}
+              :env => {'NODE_OPTIONS' => '--unhandled-rejections=strict'},
+              :chdir => source.base_dir
           }
         end
       end
@@ -200,7 +201,8 @@ module Asciidoctor
 
           {
               :args => args,
-              :out_file => output_file
+              :out_file => output_file,
+              :chdir => source.base_dir
           }
         end
       end

--- a/lib/asciidoctor-diagram/msc/converter.rb
+++ b/lib/asciidoctor-diagram/msc/converter.rb
@@ -27,7 +27,11 @@ module Asciidoctor
             args << '-F' << font
           end
           args << '-'
-          args
+
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/nomnoml/converter.rb
+++ b/lib/asciidoctor-diagram/nomnoml/converter.rb
@@ -17,7 +17,10 @@ module Asciidoctor
 
       def convert(source, format, options)
         generate_file(source.find_command('nomnoml'), 'nomnoml', format.to_s, source.to_s) do |tool_path, input_path, output_path|
-          [tool_path, Platform.native_path(input_path), Platform.native_path(output_path)]
+          {
+            :args => [tool_path, Platform.native_path(input_path), Platform.native_path(output_path)],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/penrose/converter.rb
+++ b/lib/asciidoctor-diagram/penrose/converter.rb
@@ -42,7 +42,10 @@ module Asciidoctor
           args << Platform.native_path(source.resolve_path(style_path))
           args << "--"
 
-          args
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end        
       end
     end

--- a/lib/asciidoctor-diagram/pikchr/converter.rb
+++ b/lib/asciidoctor-diagram/pikchr/converter.rb
@@ -18,7 +18,10 @@ module Asciidoctor
         pikchr_path = source.find_command('pikchr')
 
         output = generate_file_stdout(pikchr_path, format.to_s, source.to_s) do |tool_path, input_path|
-          [tool_path, "--svg-only", input_path]
+          {
+            :args => [tool_path, "--svg-only", input_path],
+            :chdir => source.base_dir
+          }
         end
 
         if output.start_with? '<svg'

--- a/lib/asciidoctor-diagram/shaape/converter.rb
+++ b/lib/asciidoctor-diagram/shaape/converter.rb
@@ -17,7 +17,10 @@ module Asciidoctor
 
       def convert(source, format, options)
         generate_stdin(source.find_command('shaape'), format.to_s, source.to_s) do |tool_path, output_path|
-          [tool_path, '-o', Platform.native_path(output_path), '-t', format.to_s, '-']
+          {
+            :args => [tool_path, '-o', Platform.native_path(output_path), '-t', format.to_s, '-'],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/smcat/converter.rb
+++ b/lib/asciidoctor-diagram/smcat/converter.rb
@@ -36,7 +36,11 @@ module Asciidoctor
           end
 
           args << '-'
-          args
+
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/svgbob/converter.rb
+++ b/lib/asciidoctor-diagram/svgbob/converter.rb
@@ -46,7 +46,10 @@ module Asciidoctor
         end
         
         generate_stdin(source.find_command('svgbob', :alt_cmds => ['svgbob_cli']), format.to_s, source.to_s) do |tool_path, output_path|
-          ([tool_path, '-o', Platform.native_path(output_path)] + flags)
+          {
+            :args => ([tool_path, '-o', Platform.native_path(output_path)] + flags),
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/symbolator/converter.rb
+++ b/lib/asciidoctor-diagram/symbolator/converter.rb
@@ -15,7 +15,10 @@ module Asciidoctor
 
       def convert(source, format, options)
         generate_stdin(source.find_command('symbolator'), format.to_s, source.to_s) do |tool_path, output_path|
-          [tool_path, "-i-", "-o#{Platform.native_path(output_path)}", "-f#{format.to_s}"]
+          {
+            :args => [tool_path, "-i-", "-o#{Platform.native_path(output_path)}", "-f#{format.to_s}"],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/syntrax/converter.rb
+++ b/lib/asciidoctor-diagram/syntrax/converter.rb
@@ -91,7 +91,10 @@ module Asciidoctor
           response[:body]
         else
           generate_file(source.find_command('syntrax'), 'spec', format.to_s, source.to_s) do |tool_path, input_path, output_path|
-            [tool_path, '-i', Platform.native_path(input_path), '-o', Platform.native_path(output_path)] + shared_args
+            {
+              :args => ([tool_path, '-i', Platform.native_path(input_path), '-o', Platform.native_path(output_path)] + shared_args),
+              :chdir => source.base_dir
+            }
           end
         end
 

--- a/lib/asciidoctor-diagram/tikz/converter.rb
+++ b/lib/asciidoctor-diagram/tikz/converter.rb
@@ -64,7 +64,10 @@ END
 
         if svgpath
           generate_file(svgpath, 'pdf', 'svg', pdf) do |tool_path, input_path, output_path|
-            [tool_path, Platform.native_path(input_path), Platform.native_path(output_path)]
+            {
+              :args => [tool_path, Platform.native_path(input_path), Platform.native_path(output_path)],
+              :chdir => source.base_dir
+            }
           end
         else
           pdf

--- a/lib/asciidoctor-diagram/umlet/converter.rb
+++ b/lib/asciidoctor-diagram/umlet/converter.rb
@@ -25,7 +25,10 @@ module Asciidoctor
         end
 
         generate_file(java, 'uxf', format.to_s, source.to_s) do |tool_path, input_path, output_path|
-          [tool_path, '-jar', Platform.native_path(umlet), '-action=convert', "-format=#{format.to_s}", "-filename=#{Platform.native_path(input_path)}", "-output=#{Platform.native_path(output_path)}"]
+          {
+            :args => [tool_path, '-jar', Platform.native_path(umlet), '-action=convert', "-format=#{format.to_s}", "-filename=#{Platform.native_path(input_path)}", "-output=#{Platform.native_path(output_path)}"],
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/vega/converter.rb
+++ b/lib/asciidoctor-diagram/vega/converter.rb
@@ -32,14 +32,16 @@ module Asciidoctor
           vega_code = code
         end
 
-        generate_file(source.find_command("vg2#{format}"), "json", format.to_s, vega_code) do |tool_path, input_path, output_path|
+        generate_stdin_stdout(source.find_command("vg2#{format}"), vega_code) do |tool_path|
           args = [tool_path, '--base', Platform.native_path(base_dir)]
           if format == :svg
             args << '--header'
           end
 
-          args << Platform.native_path(input_path)
-          args << Platform.native_path(output_path)
+          {
+            :args => args,
+            :chdir => source.base_dir
+          }
         end
       end
     end

--- a/lib/asciidoctor-diagram/wavedrom/converter.rb
+++ b/lib/asciidoctor-diagram/wavedrom/converter.rb
@@ -18,8 +18,11 @@ module Asciidoctor
       def convert(source, format, options)
         wavedrom_cli = source.find_command('wavedrom-cli', :raise_on_error => false)
         if wavedrom_cli
-          generate_file(wavedrom_cli, 'wvd', format.to_s, source.to_s) do |tool_path, input_path, output_path|
-            [Platform.native_path(tool_path), '--input', Platform.native_path(input_path), "--#{format.to_s}", Platform.native_path(output_path)]
+          generate_stdin(wavedrom_cli, format.to_s, source.to_s) do |tool_path, output_path|
+            {
+              :args => [Platform.native_path(tool_path), '--input', '-', "--#{format.to_s}", Platform.native_path(output_path)],
+              :chdir => source.base_dir
+            }
           end
         else
           wavedrom_cli = source.find_command('wavedrom', :raise_on_error => false)
@@ -27,7 +30,10 @@ module Asciidoctor
 
           if wavedrom_cli && !wavedrom_cli.include?('WaveDromEditor') && phantomjs
             generate_file(wavedrom_cli, 'wvd', format.to_s, source.to_s) do |tool_path, input_path, output_path|
-              [phantomjs, Platform.native_path(tool_path), '-i', Platform.native_path(input_path), "-#{format.to_s[0]}", Platform.native_path(output_path)]
+              {
+                :args => [phantomjs, Platform.native_path(tool_path), '-i', Platform.native_path(input_path), "-#{format.to_s[0]}", Platform.native_path(output_path)],
+                :chdir => source.base_dir
+              }
             end
           else
             if ::Asciidoctor::Diagram::Platform.os == :macosx
@@ -40,7 +46,10 @@ module Asciidoctor
             end
 
             generate_file(wavedrom, 'wvd', format.to_s, source.to_s) do |tool_path, input_path, output_path|
-              [tool_path, 'source', Platform.native_path(input_path), format.to_s, Platform.native_path(output_path)]
+              {
+                :args => [tool_path, 'source', Platform.native_path(input_path), format.to_s, Platform.native_path(output_path)],
+                :chdir => source.base_dir
+              }
             end
           end
         end


### PR DESCRIPTION
This PR applies the fix for D2 from #410 to all other diagram types.