### PR TITLE
Fixing typo in diagram type example

### DIFF
--- a/docs/modules/ROOT/pages/diagram_types/actdiag.adoc
+++ b/docs/modules/ROOT/pages/diagram_types/actdiag.adoc
@@ -6,7 +6,7 @@ include::partial$uris.adoc[]
 == Example
 
 ----
-[actidag, format="png"]
+[actdiag, format="png"]
 ....
 actdiag {
   write -> convert -> image


### PR DESCRIPTION
I found this when trying to copy-paste the example