### PR TITLE
Update PlantUML URL in docs

### DIFF
--- a/docs/modules/ROOT/partials/uris.adoc
+++ b/docs/modules/ROOT/partials/uris.adoc
@@ -28,7 +28,7 @@
 :uri-penrose: https://penrose.cs.cmu.edu
 :uri-phantomjs: http://phantomjs.org
 :uri-pikchr: https://pikchr.org
-:uri-plantuml: http://plantuml.sourceforge.net
+:uri-plantuml: https://plantuml.com/
 :uri-py-plantuml: https://code.google.com/p/asciidoc-plantuml/
 :uri-python: https://www.python.org
 :uri-rackdiag: http://blockdiag.com/en/nwdiag/index.html


### PR DESCRIPTION
This comment https://github.com/asciidoctor/asciidoctor-maven-examples/pull/244#issue-2116160739 brought attention to how to improve the Java side of things using 'smetana' dot re-implementation.

I don't think we should do more than point to the source docs, and in that sense, I think https://plantuml.com/ is a better starting point for users than the current http://plantuml.sourceforge.net