### PR TITLE
Add jsyntrax wrapper

### DIFF
--- a/deps/jsyntrax/asciidoctor-diagram-jsyntrax.gemspec
+++ b/deps/jsyntrax/asciidoctor-diagram-jsyntrax.gemspec
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+Gem::Specification.new do |s|
+  s.name          = 'asciidoctor-diagram-jsyntrax'
+  s.version       = '1.0.0'
+  s.authors       = ['Ivan Ponomarev']
+  s.email         = ['ivan@galahad.ee']
+  s.description   = %q{JSyntrax JAR files wrapped in a Ruby gem}
+  s.summary       = %q{JSyntrax JAR files wrapped in a Ruby gem}
+  s.homepage      = 'https://github.com/asciidoctor/asciidoctor-diagram'
+  s.license       = 'MIT'
+
+  s.files         = Dir['**/*']
+  s.require_paths = ['lib']
+end

--- a/deps/jsyntrax/jsyntrax-license.txt
+++ b/deps/jsyntrax/jsyntrax-license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 The department of the Algorithms and programming technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/classpath.rb
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/classpath.rb
@@ -1,0 +1,7 @@
+module Asciidoctor
+  module Diagram
+    module JsyntraxClasspath
+      JAR_FILES = Dir[File.join(File.dirname(__FILE__), '*.jar')].freeze
+    end
+  end
+end

--- a/lib/asciidoctor-diagram/syntrax/converter.rb
+++ b/lib/asciidoctor-diagram/syntrax/converter.rb
@@ -17,7 +17,12 @@ module Asciidoctor
                            lib_dir = File.expand_path('lib', CLI_HOME_ENV)
                            Dir.children(lib_dir).select { |c| c.end_with? '.jar' }.map { |c| File.expand_path(c, lib_dir) }
                          else
-                           nil
+                           begin
+                             require 'asciidoctor-diagram/jsyntrax/classpath'
+                             ::Asciidoctor::Diagram::JsyntraxClasspath::JAR_FILES
+                           rescue LoadError
+                             nil
+                           end
                          end
 
       if JSYNTRAX_JARS


### PR DESCRIPTION
Fixes #423 as discussed in the ticket. 

(Initially I thought that some student will take this work, but the academic year is over and I still would like this to be done :-) 

Dear @pepijnve , as I am not a Ruby developer, I've just mechanically copied all the stuff by analogy. And, honestly, I don't know how to test this!

Another concern is the jar file dependencies and their licenses. For the sake of simplicity I have created a shaded fat-jar with all the libraries shaded, the jsyntrax itself is under MIT license (although Apache-licensed libraries including Batik are used). 

I see, however, that for plantuml you have all the dependencies (including Batik) provided in separate jars together with their licenses. This can be done, but I'm afraid in this case there's a risk for jar hell (for example, if there are incompatible versions of Batik used in plantuml and jsyntrax). I'm relying on your suggestion here and I will be happy to redo the PR.
