### PR TITLE
Avoid infinite loop when trying to locate an attribute.

### DIFF
--- a/lib/asciidoctor-diagram/diagram_source.rb
+++ b/lib/asciidoctor-diagram/diagram_source.rb
@@ -208,6 +208,7 @@ module Asciidoctor
             if @attributes[attr_position] == name
               value = true
             end
+            attr_position += 1
           end
         end
 


### PR DESCRIPTION
This while loop will hang if it cannot find the attribute.