### PR TITLE
vega engine table

### DIFF
--- a/docs/modules/ROOT/pages/diagram_types/vega.adoc
+++ b/docs/modules/ROOT/pages/diagram_types/vega.adoc
@@ -14,8 +14,12 @@ Vega-Lite provides a more concise and convenient form to author common visualiza
 
 == Attributes
 
+[cols=">,<,<",options="header"]
+|===
+|Engine       |Binaries                                                              |Attributes
 |vega         |{uri-vega}[vg2png] and/or {uri-vega}[vg2png]                          |`vg2png` and `vg2svg`
 |vegalite     |{uri-vegalite}[vl2vg] and {uri-vega}[vg2png] and/or {uri-vega}[vg2svg]|`vl2vg`, `vg2png` and `vg2svg`
+|===
 
 [cols=">,<,<",options="header"]
 |===

--- a/docs/modules/ROOT/pages/diagram_types/vega.adoc
+++ b/docs/modules/ROOT/pages/diagram_types/vega.adoc
@@ -12,7 +12,9 @@ Vega-Lite provides a more concise and convenient form to author common visualiza
 - PNG
 - SVG
 
-== Attributes
+== Installation
+
+Required binaries:
 
 [cols=">,<,<",options="header"]
 |===
@@ -21,6 +23,8 @@ Vega-Lite provides a more concise and convenient form to author common visualiza
 |vegalite     |{uri-vegalite}[vl2vg] and {uri-vega}[vg2png] and/or {uri-vega}[vg2svg]|`vl2vg`, `vg2png` and `vg2svg`
 |===
 
+== Attributes
+
 [cols=">,<,<",options="header"]
 |===
 |Name          |Default value   |Description
@@ -28,5 +32,3 @@ Vega-Lite provides a more concise and convenient form to author common visualiza
 |vg2svg        |vg2svg          |The path to the `vg2svg` executable This attribute is used for SVG output.
 |vl2vg         |vl2vg           |The path to the `vl2vg` executable. This attribute is used for Vega-Lite diagrams.
 |===
-
-None


### PR DESCRIPTION
Currently, https://docs.asciidoctor.org/diagram-extension/latest/diagram_types/vega/ displays like this:

![image](https://github.com/user-attachments/assets/596cfbfa-01aa-4fa9-915f-e5b6a14bf44d)
