### PR TITLE
native plantuml support

### DIFF
--- a/lib/asciidoctor-diagram/plantuml/converter.rb
+++ b/lib/asciidoctor-diagram/plantuml/converter.rb
@@ -101,7 +101,9 @@ module Asciidoctor
 
       def convert_http(source, format, options)
         unless PLANTUML_JARS
-          raise "Could not load PlantUML. Either require 'asciidoctor-diagram-plantuml' or specify the location of the PlantUML JAR(s) using the 'DIAGRAM_PLANTUML_CLASSPATH' environment variable."
+          raise "Could not load PlantUML. Either require 'asciidoctor-diagram-plantuml' " \
+                "or specify the location of the PlantUML JAR(s) using the 'DIAGRAM_PLANTUML_CLASSPATH' environment variable. " \
+                "Alternatively a PlantUML binary can be provided (plantuml-native in $PATH)."
         end
         Java.load
 


### PR DESCRIPTION
I played around with the native plantuml support some more and would update the error message to mention that a native image is an option. And remove the runtime dependency because now im forced to install them even if i don't use them and as far as i can tell the imports are done in a way where it just fails if you try a diagram without support and telling you to install it. 