### PR TITLE
Fetch pikchr source from github for CI

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -131,9 +131,9 @@ jobs:
         run: sudo apt-get install -qq dpic
       - name: Install Pikchr
         run: |
-          wget https://pikchr.org/home/tarball/trunk/pikchr.tgz
-          tar -xf pikchr.tgz
-          cd pikchr
+          wget https://github.com/drhsqlite/pikchr/archive/refs/heads/master.zip
+          unzip master.zip
+          cd pikchr-master
           make
           echo "$(pwd)" >> $GITHUB_PATH
       - name: Install BPNM-JS

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -75,9 +75,9 @@ jobs:
           make PREFIX=local install
       - name: Install Pikchr
         run: |
-          wget https://pikchr.org/home/tarball/trunk/pikchr.tgz
-          tar -xf pikchr.tgz
-          cd pikchr
+          wget https://github.com/drhsqlite/pikchr/archive/refs/heads/master.zip
+          unzip master.zip
+          cd pikchr-master
           make
           echo "$(pwd)" >> $GITHUB_PATH
       - name: Install BPNM-JS


### PR DESCRIPTION
It appears that pikchr.org doesn't want bots fetching the source from their website, as they implemented a javascript bot detection script that makes wget fail.  I had copied this stanza to my own asciidoctor-diagram blog's CI, and started to see failures as of yesterday.  My failing CI run [is here](https://github.com/transactionalblog/blog/actions/runs/17004953108/job/48213190247).

Instead, there's a mirror of the pikchr source at drhsqlite/pikchr, and I don't think github cares if some CI occasionally grabs a source zip. This change works in my blog CI, so you're welcome to the same.