### PR TITLE
Adjust mermaid.adoc support

### DIFF
--- a/docs/modules/ROOT/pages/diagram_types/mermaid.adoc
+++ b/docs/modules/ROOT/pages/diagram_types/mermaid.adoc
@@ -6,9 +6,8 @@ The main purpose of Mermaid is to help documentation catch up with development.
 
 == Supported Image Formats
 
-- PDF
 - PNG
-- SVG
+- SVG (with some well known limitation for PDF renderer)
 
 == Attributes
 


### PR DESCRIPTION
PDF rendering is not quite widely support (`Failed to generate image: Asciidoctor::Diagram::MermaidBlockProcessor does not support output format pdf`) and SVG support is not working with PDF renderer due to the embed HTML mermaid uses. Ensure it is visible to end users in the doc.