### PR TITLE
Add additional support for the `--dark-theme [num]` flag with d2.

### DIFF
--- a/lib/asciidoctor-diagram/d2/converter.rb
+++ b/lib/asciidoctor-diagram/d2/converter.rb
@@ -17,6 +17,7 @@ module Asciidoctor
         {
           :layout => source.attr('layout'),
           :theme => source.attr('theme'),
+          :dark_theme => source.attr('dark-theme'),
           :pad => source.attr('pad'),
           :animate_interval => source.attr('animate-interval'),
           :sketch => source.attr('sketch'),

--- a/spec/d2_spec.rb
+++ b/spec/d2_spec.rb
@@ -120,4 +120,55 @@ a -> b
     svg = File.read(target, :encoding => Encoding::UTF_8)
     expect(svg).to_not match(/class='.*?sketch-overlay-B5.*?'/)
   end
+
+  it "should not pass --dark-theme by default" do
+    doc = <<-eos
+= Hello, d2!
+Doc Writer <doc@example.com>
+
+== First Section
+
+[d2]
+----
+a -> b
+----
+    eos
+
+    d = load_asciidoc doc
+    expect(d).to_not be_nil
+
+    b = d.find { |bl| bl.context == :image }
+    expect(b).to_not be_nil
+    target = b.attributes['target']
+    expect(target).to match(/\.svg$/)
+    expect(File.exist?(target)).to be true
+    svg = File.read(target, :encoding => Encoding::UTF_8)
+    expect(svg.scan(".stroke-N1").size).to eq(1)
+  end
+
+  it "should generate multiple sets of css classes when the dark-theme attribute is set" do
+    doc = <<-eos
+= Hello, d2!
+Doc Writer <doc@example.com>
+
+== First Section
+
+[d2, dark-theme="200"]
+----
+a -> b
+----
+    eos
+
+    d = load_asciidoc doc
+    expect(d).to_not be_nil
+
+    b = d.find { |bl| bl.context == :image }
+    expect(b).to_not be_nil
+    target = b.attributes['target']
+    expect(target).to match(/\.svg$/)
+    expect(File.exist?(target)).to be true
+    svg = File.read(target, :encoding => Encoding::UTF_8)
+    # the additional dark theme defines an additional class:
+    expect(svg.scan(".stroke-N1").size).to eq(2)
+  end
 end


### PR DESCRIPTION
Adds support for the dark-theme attribute in d2.

See this 2023 blog post from d2lang for an example of how it is supposed to be used: [d2lang.com/blog/dark-mode](https://d2lang.com/blog/dark-mode/)

I added two test cases to show it works, snippet of test results pasted below:

```
asciidoctor: DEBUG: Finding 'd2' in attributes
asciidoctor: DEBUG: Finding 'd2' in environment
asciidoctor: DEBUG: Found '/usr/local/bin/d2' in environment
asciidoctor: DEBUG: Executing ["/usr/local/bin/d2", "--browser", "false", "-", "/tmp/d220260628-2139-18krsa.svg"] with options {stdin_data: "a -> b", chdir: "/workspace/testing/Asciidoctor_Diagram_D2BlockProcessor/should_not_pass_dark_theme_by_default"} and environment {}
  should not pass --dark-theme by default
asciidoctor: DEBUG: Finding 'd2' in attributes
asciidoctor: DEBUG: Finding 'd2' in environment
asciidoctor: DEBUG: Found '/usr/local/bin/d2' in environment
asciidoctor: DEBUG: Executing ["/usr/local/bin/d2", "--browser", "false", "--dark-theme", "200", "-", "/tmp/d220260628-2139-n1yb2r.svg"] with options {stdin_data: "a -> b", chdir: "/workspace/testing/Asciidoctor_Diagram_D2BlockProcessor/should_generate_multiple_sets_of_css_classes_when_the_dark_theme_attribute_is_set"} and environment {}
  should generate multiple sets of css classes when the dark-theme attribute is set

Finished in 9.1 seconds (files took 0.22486 seconds to load)
40 examples, 0 failures
```