### PR TITLE
Update JSyntrax to 1.39

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@
 Enhancements::
 
 * PR #515: Add support for D2 dark theme (@hgibs)
+* Update bundled JSyntrax to 1.39 and remove the Groovy runtime dependency.
 
 == 3.2.1
 

--- a/deps/jsyntrax/asciidoctor-diagram-jsyntrax.gemspec
+++ b/deps/jsyntrax/asciidoctor-diagram-jsyntrax.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'asciidoctor-diagram-jsyntrax'
-  s.version       = '1.38.2'
+  s.version       = '1.39'
   s.authors       = ['Ivan Ponomarev']
   s.email         = ['ivan@galahad.ee']
   s.description   = %q{JSyntrax JAR files wrapped in a Ruby gem}

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-cli-1.11.0.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-cli-1.11.0.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f7f8605d68e15bf32db61ec94eac6fdafc51b1bdbe1e0e0802b57d23f387792
+size 110167

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-cli-1.8.0.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-cli-1.8.0.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f94c98bbcfa1c1dac6956d6c3f494ec40265c67bf54ddefc95df4ffdd73ae6d5
-size 73599

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-io-2.11.0.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-io-2.11.0.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908
-size 327135

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-logging-1.0.4.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/commons-logging-1.0.4.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e94af49749384c11f5aa50e8d0f5fe679be771295b52030338d32843c980351e
-size 38015

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/groovy-4.0.22.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/groovy-4.0.22.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9d8bd4d65852c18194e353c77f3d2c23e0013856951c5430ba56972d2f67a1e
-size 7601005

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/jsyntrax-1.38.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/jsyntrax-1.38.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11fe2adc6f16b5c61234a8fa9627f3147bc1f821b0918bd5044da4ac164d7d70
-size 84497

--- a/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/jsyntrax-1.39.jar
+++ b/deps/jsyntrax/lib/asciidoctor-diagram/jsyntrax/jsyntrax-1.39.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac69ef7da9d6f9513ca6b128642a98bdc29b9dea1bf01d69c06e18eebb98640e
+size 105485


### PR DESCRIPTION
[JSyntrax v 1.39](https://github.com/atp-mipt/jsyntrax/releases/tag/1.39) no longer depends on Groovy, so we have less security concerns and jar hell in dependencies